### PR TITLE
fix: preserve cache capacity on clear and remove unsafe transmute

### DIFF
--- a/src/common/frequency_sketch.rs
+++ b/src/common/frequency_sketch.rs
@@ -207,7 +207,7 @@ mod tests {
     static ITEM: Lazy<u32> = Lazy::new(|| {
         let mut buf = [0; 4];
         getrandom::getrandom(&mut buf).unwrap();
-        unsafe { std::mem::transmute::<[u8; 4], u32>(buf) }
+        u32::from_ne_bytes(buf)
     });
 
     // This test was ported from Caffeine.

--- a/src/unsync/cache.rs
+++ b/src/unsync/cache.rs
@@ -311,9 +311,10 @@ where
         // Swap out the cache before resetting internal state so that a panic
         // in V::drop leaves `self` in a consistent (empty) state rather than
         // with stale deque pointers or a stale entry_count.
+        let old_capacity = self.cache.capacity();
         let old_cache = std::mem::replace(
             &mut self.cache,
-            HashMap::with_hasher(self.build_hasher.clone()),
+            HashMap::with_capacity_and_hasher(old_capacity, self.build_hasher.clone()),
         );
         self.deques.clear();
         self.entry_count = 0;

--- a/src/unsync/cache.rs
+++ b/src/unsync/cache.rs
@@ -308,17 +308,21 @@ where
     /// popularity estimator of keys so that it retains the client activities of
     /// trying to retrieve an item.
     pub fn invalidate_all(&mut self) {
-        // Swap out the cache before resetting internal state so that a panic
-        // in V::drop leaves `self` in a consistent (empty) state rather than
-        // with stale deque pointers or a stale entry_count.
+        // Phase 1: swap out the cache before resetting internal state so that
+        // a panic in V::drop leaves `self` in a consistent (empty) state.
         let old_capacity = self.cache.capacity();
         let old_cache = std::mem::replace(
             &mut self.cache,
-            HashMap::with_capacity_and_hasher(old_capacity, self.build_hasher.clone()),
+            HashMap::with_hasher(self.build_hasher.clone()),
         );
         self.deques.clear();
         self.entry_count = 0;
+
+        // If V::drop panics, `self` is already in a valid empty state.
         drop(old_cache);
+
+        // Phase 2: best effort capacity restoration for future inserts.
+        let _ = self.cache.try_reserve(old_capacity);
     }
 
     /// Discards cached values that satisfy a predicate.


### PR DESCRIPTION
## Summary
- preserve `HashMap` capacity in `unsync::Cache::invalidate_all` while keeping panic-safe state reset semantics
- replace unnecessary unsafe transmute in frequency sketch tests with `u32::from_ne_bytes`

## Why
- avoids allocation churn when repeatedly clearing and refilling caches
- removes avoidable unsafe code and compiler warning surface

## Validation
- `cargo test` (25 unit tests + 5 doctests)
