### PR TITLE
perf: simplify hot paths for unsync cache

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ readme = "README.md"
 exclude = [".circleci", ".devcontainer", ".github", ".gitpod.yml", ".vscode"]
 
 [dependencies]
-smallvec = "1.8"
 tagptr = "0.2"
 
 # Opt-out serde and stable_deref_trait features

--- a/src/common/deque.rs
+++ b/src/common/deque.rs
@@ -46,6 +46,7 @@ impl<T> DeqNode<T> {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn next_node_ptr(this: NonNull<Self>) -> Option<NonNull<DeqNode<T>>> {
         unsafe { this.as_ref() }.next
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ pub mod unsync;
 
 pub use policy::Policy;
 
-#[cfg(all(doctest))]
+#[cfg(doctest)]
 mod doctests {
     // https://doc.rust-lang.org/rustdoc/write-documentation/documentation-tests.html#include-items-only-when-collecting-doctests
     #[doc = include_str!("../README.md")]


### PR DESCRIPTION
## Summary
- remove `evict_lru_entries()` from read-only operations (`get` and `contains_key`) so eviction remains write-triggered
- specialize TinyLFU admission for the weight=1 model by comparing candidate frequency against a single probation LRU victim
- keep deque membership validation in debug builds while avoiding release-mode `contains()` checks on hot deque operations
- remove now-unused `smallvec` dependency

## Validation
- `cargo fmt --all`
- `cargo test -q`
- `cargo clippy --lib --tests --all-features --all-targets -- -D warnings`
