### PR TITLE
Fix crates publish workflow (remove blocked API precheck)

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -36,30 +36,37 @@ jobs:
           echo "version=$(.github/scripts/cargo-package-field.sh Cargo.toml version)" >> "$GITHUB_OUTPUT"
           echo "tag=v$(.github/scripts/cargo-package-field.sh Cargo.toml version)" >> "$GITHUB_OUTPUT"
 
-      - name: Check crates.io for existing version
-        id: crates
+      - name: Validate crates.io token presence
         env:
-          CRATE_NAME: ${{ steps.meta.outputs.crate_name }}
-          VERSION: ${{ steps.meta.outputs.version }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
-          STATUS="$(curl -sS -o /tmp/crates-version.json -w '%{http_code}' "https://crates.io/api/v1/crates/${CRATE_NAME}/${VERSION}")"
-          if [ "$STATUS" = "200" ]; then
-            echo "published=true" >> "$GITHUB_OUTPUT"
-            echo "Version ${VERSION} is already published on crates.io."
-          elif [ "$STATUS" = "404" ]; then
-            echo "published=false" >> "$GITHUB_OUTPUT"
-            echo "Version ${VERSION} is not published yet."
-          else
-            echo "Unexpected crates.io response code: $STATUS" >&2
-            cat /tmp/crates-version.json >&2 || true
+          if [ -z "${CARGO_REGISTRY_TOKEN:-}" ]; then
+            echo "Missing required repository secret: CARGO_REGISTRY_TOKEN" >&2
             exit 1
           fi
 
       - name: Publish crate
-        if: steps.crates.outputs.published != 'true'
+        id: publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish --locked
+        run: |
+          set -o pipefail
+          LOG_FILE="$(mktemp)"
+
+          if cargo publish --locked 2>&1 | tee "$LOG_FILE"; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+            echo "Publish succeeded."
+            exit 0
+          fi
+
+          if grep -Eqi "(already uploaded|already exists|previously uploaded)" "$LOG_FILE"; then
+            echo "published=false" >> "$GITHUB_OUTPUT"
+            echo "Version already published on crates.io. Continuing."
+            exit 0
+          fi
+
+          echo "cargo publish failed with an unexpected error." >&2
+          exit 1
 
       - name: Ensure git tag exists
         id: tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.6] - 2026-02-27
+
+### Fixed
+
+- Fixed release publish automation to avoid crates.io API pre-checks that can return 403 under data-access policy enforcement.
+- Made publish step idempotent by treating "already uploaded" responses from `cargo publish` as success.
+
 ## [0.1.5] - 2026-02-27
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "micro-moka"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2018"
 rust-version = "1.76"
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -32,4 +32,4 @@ Every PR targeting `main` must:
 4. Ensures git tag `v<version>` exists.
 5. Creates a GitHub release from the matching changelog section.
 
-The publish workflow is idempotent: re-runs will skip publishing if crates.io already has that version.
+The publish workflow is idempotent: re-runs treat "already uploaded" from `cargo publish` as success.


### PR DESCRIPTION
## Summary
- remove crates.io API pre-check that can return 403 in GitHub Actions
- publish directly with `cargo publish --locked`
- treat `already uploaded`-style publish responses as success (idempotent)
- fail fast with a clear message when `CARGO_REGISTRY_TOKEN` is missing
- bump crate version to `0.1.6` and add changelog entry

## Why
The previous workflow called `https://crates.io/api/v1/crates/<name>/<version>` and failed with 403 due to crates.io data-access policy enforcement.

This PR removes that dependency and relies on Cargo's publish response instead.
