### PR TITLE
perf: skip frequency sketch increment on cache misses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.7] - 2026-02-28
+
+### Changed
+
+- Stopped incrementing the frequency sketch on cache misses in `get()`, avoiding wasted work and frequency sketch pollution from keys that are not in the cache.
+
 ## [0.1.6] - 2026-02-27
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "micro-moka"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2018"
 rust-version = "1.76"
 


### PR DESCRIPTION
## Summary

- Moved the frequency sketch increment (`record_read_in_freq_sketch`) from unconditional execution in `get()` to inside the cache-hit branch only, avoiding wasted Count-Min Sketch lookups and increments on misses
- Updated `basic_single_thread` test to build key frequency through actual cache hits rather than relying on misses
- Added a dedicated `frequency_sketch_only_increments_on_hit` test to verify the new behavior
- Bumped version to 0.1.7 with changelog entry

## Rationale

On a cache miss the key will never participate in an eviction decision until it is actually inserted, so incrementing its frequency counter is unnecessary work. This reduces overhead on miss-heavy workloads.

## Files changed

- `src/unsync/cache.rs` - moved `record_read_in_freq_sketch` call, updated and added tests
- `Cargo.toml` - version bump to 0.1.7
- `CHANGELOG.md` - added entry for the optimization

## Test results

All existing and new tests pass with `RUSTFLAGS='--cfg trybuild' cargo test --all-features`.