### PR TITLE
Replace three-deque eviction structure with single deque

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.7] - 2026-02-28
+
+### Changed
+
+- Replaced three-deque `Deques<K>` struct (window, probation, protected) with a single `Deque<KeyHashDate<K>>`, eliminating ~80 bytes of unused deque overhead per cache instance.
+- Removed `CacheRegion` enum and all tagged-pointer (`TagNonNull`) dispatch from access-order operations, simplifying every cache hit/insert/evict path.
+- Removed `#[repr(align(4))]` from `DeqNode` now that 2-bit tag encoding is no longer needed.
+- Removed `tagptr` dependency.
+
 ## [0.1.6] - 2026-02-27
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "micro-moka"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2018"
 rust-version = "1.76"
 
@@ -15,8 +15,6 @@ readme = "README.md"
 exclude = [".circleci", ".devcontainer", ".github", ".gitpod.yml", ".vscode"]
 
 [dependencies]
-tagptr = "0.2"
-
 # Opt-out serde and stable_deref_trait features
 # https://github.com/Manishearth/triomphe/pull/5
 triomphe = { version = "0.1.13", default-features = false }

--- a/src/common.rs
+++ b/src/common.rs
@@ -3,41 +3,6 @@ use std::convert::TryInto;
 pub(crate) mod deque;
 pub(crate) mod frequency_sketch;
 
-// Note: `CacheRegion` cannot have more than four enum variants. This is because
-// `crate::{sync,unsync}::DeqNodes` uses a `tagptr::TagNonNull<DeqNode<T>, 2>`
-// pointer, where the 2-bit tag is `CacheRegion`.
-#[derive(Clone, Copy, Debug, Eq)]
-pub(crate) enum CacheRegion {
-    Window = 0,
-    MainProbation = 1,
-    MainProtected = 2,
-    Other = 3,
-}
-
-impl From<usize> for CacheRegion {
-    fn from(n: usize) -> Self {
-        match n {
-            0 => Self::Window,
-            1 => Self::MainProbation,
-            2 => Self::MainProtected,
-            3 => Self::Other,
-            _ => panic!("No such CacheRegion variant for {}", n),
-        }
-    }
-}
-
-impl PartialEq<Self> for CacheRegion {
-    fn eq(&self, other: &Self) -> bool {
-        core::mem::discriminant(self) == core::mem::discriminant(other)
-    }
-}
-
-impl PartialEq<usize> for CacheRegion {
-    fn eq(&self, other: &usize) -> bool {
-        *self as usize == *other
-    }
-}
-
 // Ensures the value fits in a range of `128u32..=u32::MAX`.
 pub(crate) fn sketch_capacity(max_capacity: u64) -> u32 {
     max_capacity.try_into().unwrap_or(u32::MAX).max(128)

--- a/src/common/deque.rs
+++ b/src/common/deque.rs
@@ -14,13 +14,6 @@
 
 use std::{marker::PhantomData, ptr::NonNull};
 
-use super::CacheRegion;
-
-// `crate::{sync,unsync}::DeqNodes` uses a `tagptr::TagNonNull<DeqNode<T>, 2>`
-// pointer. To reserve the space for the 2-bit tag, use 4 bytes as the *minimum*
-// alignment.
-// https://doc.rust-lang.org/reference/type-layout.html#the-alignment-modifiers
-#[repr(align(4))]
 #[derive(PartialEq, Eq)]
 pub(crate) struct DeqNode<T> {
     next: Option<NonNull<DeqNode<T>>>,
@@ -59,7 +52,6 @@ enum DeqCursor<T> {
 }
 
 pub(crate) struct Deque<T> {
-    region: CacheRegion,
     len: usize,
     head: Option<NonNull<DeqNode<T>>>,
     tail: Option<NonNull<DeqNode<T>>>,
@@ -89,19 +81,14 @@ impl<T> Drop for Deque<T> {
 
 // Inner crate public function/methods
 impl<T> Deque<T> {
-    pub(crate) fn new(region: CacheRegion) -> Self {
+    pub(crate) fn new() -> Self {
         Self {
-            region,
             len: 0,
             head: None,
             tail: None,
             cursor: None,
             marker: PhantomData,
         }
-    }
-
-    pub(crate) fn region(&self) -> CacheRegion {
-        self.region
     }
 
     #[cfg(test)]
@@ -355,12 +342,12 @@ impl<T> Deque<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::{CacheRegion::MainProbation, DeqNode, Deque};
+    use super::{DeqNode, Deque};
 
     #[test]
     #[allow(clippy::cognitive_complexity)]
     fn basics() {
-        let mut deque: Deque<String> = Deque::new(MainProbation);
+        let mut deque: Deque<String> = Deque::new();
         assert_eq!(deque.len(), 0);
         assert!(deque.peek_front().is_none());
         assert!(deque.peek_back().is_none());
@@ -616,7 +603,7 @@ mod tests {
 
     #[test]
     fn iter() {
-        let mut deque: Deque<String> = Deque::new(MainProbation);
+        let mut deque: Deque<String> = Deque::new();
         assert!((&mut deque).next().is_none());
 
         let node1 = DeqNode::new("a".into());
@@ -691,7 +678,7 @@ mod tests {
 
     #[test]
     fn next_node() {
-        let mut deque: Deque<String> = Deque::new(MainProbation);
+        let mut deque: Deque<String> = Deque::new();
 
         let node1 = DeqNode::new("a".into());
         deque.push_back(Box::new(node1));
@@ -736,7 +723,7 @@ mod tests {
 
     #[test]
     fn peek_and_move_to_back() {
-        let mut deque: Deque<String> = Deque::new(MainProbation);
+        let mut deque: Deque<String> = Deque::new();
 
         let node1 = DeqNode::new("a".into());
         deque.push_back(Box::new(node1));
@@ -765,8 +752,8 @@ mod tests {
 
     #[test]
     fn reachable_from_head_rejects_foreign_non_head_node() {
-        let mut deque_a: Deque<String> = Deque::new(MainProbation);
-        let mut deque_b: Deque<String> = Deque::new(MainProbation);
+        let mut deque_a: Deque<String> = Deque::new();
+        let mut deque_b: Deque<String> = Deque::new();
 
         deque_a.push_back(Box::new(DeqNode::new("a1".into())));
         deque_a.push_back(Box::new(DeqNode::new("a2".into())));
@@ -788,8 +775,8 @@ mod tests {
     fn contains_panics_on_foreign_non_head_node() {
         use std::panic::{catch_unwind, AssertUnwindSafe};
 
-        let mut deque_a: Deque<String> = Deque::new(MainProbation);
-        let mut deque_b: Deque<String> = Deque::new(MainProbation);
+        let mut deque_a: Deque<String> = Deque::new();
+        let mut deque_b: Deque<String> = Deque::new();
 
         deque_a.push_back(Box::new(DeqNode::new("a1".into())));
         deque_a.push_back(Box::new(DeqNode::new("a2".into())));
@@ -807,7 +794,7 @@ mod tests {
 
     #[test]
     fn contains_rejects_unlinked_node() {
-        let mut deque: Deque<String> = Deque::new(MainProbation);
+        let mut deque: Deque<String> = Deque::new();
 
         let node1 = DeqNode::new("a".to_string());
         let node1_ptr = deque.push_back(Box::new(node1));
@@ -836,7 +823,7 @@ mod tests {
             }
         }
 
-        let mut deque: Deque<X> = Deque::new(MainProbation);
+        let mut deque: Deque<X> = Deque::new();
         let dropped = Rc::new(RefCell::new(Vec::default()));
 
         let node1 = DeqNode::new(X(1, Rc::clone(&dropped)));

--- a/src/unsync.rs
+++ b/src/unsync.rs
@@ -8,8 +8,8 @@ mod cache;
 mod deques;
 mod iter;
 
+use std::ptr::NonNull;
 use std::rc::Rc;
-use tagptr::TagNonNull;
 
 pub use builder::CacheBuilder;
 pub use cache::Cache;
@@ -28,8 +28,7 @@ impl<K> KeyHashDate<K> {
     }
 }
 
-// DeqNode for an access order queue.
-type KeyDeqNodeAo<K> = TagNonNull<DeqNode<KeyHashDate<K>>, 2>;
+type KeyDeqNodeAo<K> = NonNull<DeqNode<KeyHashDate<K>>>;
 
 struct EntryInfo<K> {
     access_order_q_node: Option<KeyDeqNodeAo<K>>,

--- a/src/unsync/cache.rs
+++ b/src/unsync/cache.rs
@@ -1,6 +1,6 @@
 use super::{deques::Deques, CacheBuilder, Iter, KeyHashDate, ValueEntry};
 use crate::{
-    common::{self, deque::DeqNode, frequency_sketch::FrequencySketch, CacheRegion},
+    common::{self, deque::DeqNode, frequency_sketch::FrequencySketch},
     Policy,
 };
 
@@ -466,12 +466,10 @@ where
             let key = Rc::clone(&key);
             let entry = cache.get_mut(&key).unwrap();
             deqs.push_back_ao(
-                CacheRegion::MainProbation,
                 KeyHashDate::new(Rc::clone(&key), hash),
                 entry,
             );
             self.entry_count += 1;
-            // self.saturating_add_to_total_weight(policy_weight as u64);
 
             if self.should_enable_frequency_sketch() {
                 self.enable_frequency_sketch();
@@ -503,7 +501,6 @@ where
                 let entry = cache.get_mut(&key).unwrap();
                 let key = Rc::clone(&key);
                 deqs.push_back_ao(
-                    CacheRegion::MainProbation,
                     KeyHashDate::new(Rc::clone(&key), hash),
                     entry,
                 );
@@ -534,7 +531,7 @@ where
     ///
     #[inline]
     fn admit(candidate_freq: u8, deqs: &Deques<K>, freq: &FrequencySketch) -> AdmissionResult<K> {
-        let Some(victim_node) = deqs.probation.peek_front_ptr() else {
+        let Some(victim_node) = deqs.deque.peek_front_ptr() else {
             return AdmissionResult::Rejected;
         };
         let victim_hash = unsafe { victim_node.as_ref() }.element.hash;
@@ -564,25 +561,21 @@ where
 
     #[inline]
     fn evict_lru_entries(&mut self) {
-        const DEQ_NAME: &str = "probation";
-
         let weights_to_evict = self.weights_to_evict();
         let mut evicted_count = 0u64;
         let mut evicted_policy_weight = 0u64;
 
         {
             let deqs = &mut self.deques;
-            let (probation, cache) = (&mut deqs.probation, &mut self.cache);
+            let (deque, cache) = (&mut deqs.deque, &mut self.cache);
 
             for _ in 0..EVICTION_BATCH_SIZE {
                 if evicted_policy_weight >= weights_to_evict {
                     break;
                 }
 
-                // clippy::map_clone will give us a false positive warning here.
-                // Version: clippy 0.1.77 (f2048098a1c 2024-02-09) in Rust 1.77.0-beta.2
                 #[allow(clippy::map_clone)]
-                let key = probation
+                let key = deque
                     .peek_front()
                     .map(|node| Rc::clone(&node.element.key));
 
@@ -593,17 +586,16 @@ where
 
                 if let Some(mut entry) = cache.remove(&key) {
                     let weight = entry.policy_weight();
-                    Deques::unlink_ao_from_deque(DEQ_NAME, probation, &mut entry);
+                    Deques::unlink_ao_from_deque(deque, &mut entry);
                     evicted_count += 1;
                     evicted_policy_weight = evicted_policy_weight.saturating_add(weight as u64);
                 } else {
-                    probation.pop_front();
+                    deque.pop_front();
                 }
             }
         }
 
         self.entry_count -= evicted_count;
-        // self.saturating_sub_from_total_weight(evicted_policy_weight);
     }
 }
 

--- a/src/unsync/deques.rs
+++ b/src/unsync/deques.rs
@@ -1,81 +1,38 @@
 use super::{KeyHashDate, ValueEntry};
-use crate::common::{
-    deque::{DeqNode, Deque},
-    CacheRegion,
-};
+use crate::common::deque::{DeqNode, Deque};
 
-use tagptr::TagNonNull;
+use std::ptr::NonNull;
 
 pub(crate) struct Deques<K> {
-    pub(crate) window: Deque<KeyHashDate<K>>, //    Not used yet.
-    pub(crate) probation: Deque<KeyHashDate<K>>,
-    pub(crate) protected: Deque<KeyHashDate<K>>, // Not used yet.
+    pub(crate) deque: Deque<KeyHashDate<K>>,
 }
 
 impl<K> Default for Deques<K> {
     fn default() -> Self {
         Self {
-            window: Deque::new(CacheRegion::Window),
-            probation: Deque::new(CacheRegion::MainProbation),
-            protected: Deque::new(CacheRegion::MainProtected),
+            deque: Deque::new(),
         }
     }
 }
 
 impl<K> Deques<K> {
     pub(crate) fn clear(&mut self) {
-        self.window = Deque::new(CacheRegion::Window);
-        self.probation = Deque::new(CacheRegion::MainProbation);
-        self.protected = Deque::new(CacheRegion::MainProtected);
+        self.deque = Deque::new();
     }
 
     pub(crate) fn push_back_ao<V>(
         &mut self,
-        region: CacheRegion,
         kh: KeyHashDate<K>,
         entry: &mut ValueEntry<K, V>,
     ) {
         let node = Box::new(DeqNode::new(kh));
-        let node = match region {
-            CacheRegion::Window => self.window.push_back(node),
-            CacheRegion::MainProbation => self.probation.push_back(node),
-            CacheRegion::MainProtected => self.protected.push_back(node),
-            CacheRegion::Other => unreachable!(),
-        };
-        let tagged_node = TagNonNull::compose(node, region as usize);
-        entry.set_access_order_q_node(Some(tagged_node));
+        let node = self.deque.push_back(node);
+        entry.set_access_order_q_node(Some(node));
     }
 
     pub(crate) fn move_to_back_ao<V>(&mut self, entry: &ValueEntry<K, V>) {
-        if let Some(tagged_node) = entry.access_order_q_node() {
-            let (node, tag) = tagged_node.decompose();
-            match tag.into() {
-                CacheRegion::Window => {
-                    #[cfg(debug_assertions)]
-                    {
-                        let p = unsafe { node.as_ref() };
-                        debug_assert!(self.window.contains(p));
-                    }
-                    unsafe { self.window.move_to_back(node) };
-                }
-                CacheRegion::MainProbation => {
-                    #[cfg(debug_assertions)]
-                    {
-                        let p = unsafe { node.as_ref() };
-                        debug_assert!(self.probation.contains(p));
-                    }
-                    unsafe { self.probation.move_to_back(node) };
-                }
-                CacheRegion::MainProtected => {
-                    #[cfg(debug_assertions)]
-                    {
-                        let p = unsafe { node.as_ref() };
-                        debug_assert!(self.protected.contains(p));
-                    }
-                    unsafe { self.protected.move_to_back(node) };
-                }
-                _ => unreachable!(),
-            }
+        if let Some(node) = entry.access_order_q_node() {
+            unsafe { self.deque.move_to_back(node) };
         }
     }
 
@@ -86,57 +43,22 @@ impl<K> Deques<K> {
     }
 
     pub(crate) fn unlink_ao_from_deque<V>(
-        deq_name: &str,
         deq: &mut Deque<KeyHashDate<K>>,
         entry: &mut ValueEntry<K, V>,
     ) {
         if let Some(node) = entry.take_access_order_q_node() {
-            unsafe { Self::unlink_node_ao_from_deque(deq_name, deq, node) };
+            unsafe { Self::unlink_node(deq, node) };
         }
     }
 
-    pub(crate) fn unlink_node_ao(&mut self, tagged_node: TagNonNull<DeqNode<KeyHashDate<K>>, 2>) {
-        unsafe {
-            match tagged_node.decompose_tag().into() {
-                CacheRegion::Window => {
-                    Self::unlink_node_ao_from_deque("window", &mut self.window, tagged_node)
-                }
-                CacheRegion::MainProbation => {
-                    Self::unlink_node_ao_from_deque("probation", &mut self.probation, tagged_node)
-                }
-                CacheRegion::MainProtected => {
-                    Self::unlink_node_ao_from_deque("protected", &mut self.protected, tagged_node)
-                }
-                _ => unreachable!(),
-            }
-        }
+    pub(crate) fn unlink_node_ao(&mut self, node: NonNull<DeqNode<KeyHashDate<K>>>) {
+        unsafe { Self::unlink_node(&mut self.deque, node) };
     }
 
-    unsafe fn unlink_node_ao_from_deque(
-        deq_name: &str,
+    unsafe fn unlink_node(
         deq: &mut Deque<KeyHashDate<K>>,
-        tagged_node: TagNonNull<DeqNode<KeyHashDate<K>>, 2>,
+        node: NonNull<DeqNode<KeyHashDate<K>>>,
     ) {
-        let (node, tag) = tagged_node.decompose();
-        if deq.region() != tag {
-            panic!(
-                "unlink_node - node is not a member of {} deque. {:?}",
-                deq_name,
-                node.as_ref()
-            )
-        }
-
-        #[cfg(debug_assertions)]
-        {
-            if !deq.contains(node.as_ref()) {
-                panic!(
-                    "unlink_node - node is not a member of {} deque. {:?}",
-                    deq_name,
-                    node.as_ref()
-                )
-            }
-        }
-
         // https://github.com/moka-rs/moka/issues/64
         deq.unlink_and_drop(node);
     }


### PR DESCRIPTION
## Summary

Replaced the three-deque `Deques<K>` struct (window, probation, protected) with a single `Deque<KeyHashDate<K>>`, removing unused eviction infrastructure inherited from Mini Moka.

## What changed

- Removed `CacheRegion` enum and all `TagNonNull` tagged-pointer dispatch
- Removed `#[repr(align(4))]` from `DeqNode` (no longer needed without 2-bit region tags)
- Dropped the `tagptr` dependency from `Cargo.toml`
- Simplified every access-order hot path from tag-decompose-and-match to a direct deque call
- Eliminates ~80 bytes of unused deque overhead per cache instance

## Files changed

- `Cargo.toml` - version bump to 0.1.7, removed `tagptr` dependency
- `CHANGELOG.md` - documented the optimization
- `src/common.rs` - removed `CacheRegion` enum
- `src/common/deque.rs` - removed alignment requirement and region tagging
- `src/unsync.rs` - removed `deques` module re-export
- `src/unsync/cache.rs` - simplified eviction logic to use single deque
- `src/unsync/deques.rs` - replaced `Deques<K>` with single deque

## Test results

All 25 unit tests and 5 doc tests pass. Clippy clean with `--all-features`.