### PR TITLE
perf: add #[inline] hints to hot-path API and frequency sketch methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.8] - 2026-02-28
+
+### Changed
+
+- Added `#[inline]` to hot path public API functions (`get`, `insert`, `contains_key`, `invalidate`, `remove`) and core private helpers (`record_hit`, `has_enough_capacity`, `weights_to_evict`, `handle_update`) to enable cross-crate inlining for downstream users.
+- Added `#[inline]` to frequency sketch hot path methods (`frequency`, `increment`, `index_of`, `increment_at`) for better inlining in the admission/eviction loop.
+- Split `evict_lru_entries()` into a thin `#[inline]` early-return check and a `#[cold] #[inline(never)]` inner body (`do_evict_lru_entries`) so the common no-eviction path stays in the instruction cache.
+- Marked `invalidate_all()` and `invalidate_entries_if()` as `#[cold] #[inline(never)]` to keep infrequent bulk operations out of the hot instruction cache.
+
 ## [0.1.7] - 2026-02-28
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "micro-moka"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2018"
 rust-version = "1.76"
 

--- a/src/common/frequency_sketch.rs
+++ b/src/common/frequency_sketch.rs
@@ -111,6 +111,7 @@ impl FrequencySketch {
 
     /// Takes the hash value of an element, and returns the estimated number of
     /// occurrences of the element, up to the maximum (15).
+    #[inline]
     pub(crate) fn frequency(&self, hash: u64) -> u8 {
         if self.table.is_empty() {
             return 0;
@@ -132,6 +133,7 @@ impl FrequencySketch {
     /// elements will be periodically down sampled when the observed events
     /// exceeds a threshold. This process provides a frequency aging to allow
     /// expired long term entries to fade away.
+    #[inline]
     pub(crate) fn increment(&mut self, hash: u64) {
         if self.table.is_empty() {
             return;
@@ -155,6 +157,7 @@ impl FrequencySketch {
     /// Takes a table index (each entry has 16 counters) and counter index, and
     /// increments the counter by 1 if it is not already at the maximum value
     /// (15). Returns `true` if incremented.
+    #[inline]
     fn increment_at(&mut self, table_index: usize, counter_index: u8) -> bool {
         let offset = (counter_index as usize) << 2;
         let mask = 0xF_u64 << offset;
@@ -178,6 +181,7 @@ impl FrequencySketch {
     }
 
     /// Returns the table index for the counter at the specified depth.
+    #[inline]
     fn index_of(&self, hash: u64, depth: u8) -> usize {
         let i = depth as usize;
         let mut hash = hash.wrapping_add(SEED[i]).wrapping_mul(SEED[i]);

--- a/src/unsync/cache.rs
+++ b/src/unsync/cache.rs
@@ -220,6 +220,7 @@ where
     ///
     /// The key may be any borrowed form of the cache's key type, but `Hash` and `Eq`
     /// on the borrowed form _must_ match those for the key type.
+    #[inline]
     pub fn contains_key<Q>(&mut self, key: &Q) -> bool
     where
         Rc<K>: Borrow<Q>,
@@ -232,6 +233,7 @@ where
     ///
     /// The key may be any borrowed form of the cache's key type, but `Hash` and `Eq`
     /// on the borrowed form _must_ match those for the key type.
+    #[inline]
     pub fn get<Q>(&mut self, key: &Q) -> Option<&V>
     where
         Rc<K>: Borrow<Q>,
@@ -257,6 +259,7 @@ where
     /// Inserts a key-value pair into the cache.
     ///
     /// If the cache has this key present, the value is updated.
+    #[inline]
     pub fn insert(&mut self, key: K, value: V) {
         self.evict_lru_entries();
         let policy_weight = 1;
@@ -287,6 +290,7 @@ where
     ///
     /// The key may be any borrowed form of the cache's key type, but `Hash` and `Eq`
     /// on the borrowed form _must_ match those for the key type.
+    #[inline]
     pub fn invalidate<Q>(&mut self, key: &Q)
     where
         Rc<K>: Borrow<Q>,
@@ -304,6 +308,7 @@ where
     ///
     /// The key may be any borrowed form of the cache's key type, but `Hash` and `Eq`
     /// on the borrowed form _must_ match those for the key type.
+    #[inline]
     pub fn remove<Q>(&mut self, key: &Q) -> Option<V>
     where
         Rc<K>: Borrow<Q>,
@@ -325,6 +330,8 @@ where
     /// Like the `invalidate` method, this method does not clear the historic
     /// popularity estimator of keys so that it retains the client activities of
     /// trying to retrieve an item.
+    #[cold]
+    #[inline(never)]
     pub fn invalidate_all(&mut self) {
         // Phase 1: swap out the cache before resetting internal state so that
         // a panic in V::drop leaves `self` in a consistent (empty) state.
@@ -357,6 +364,8 @@ where
     // We need this #[allow(...)] to avoid a false Clippy warning about needless
     // collect to create keys_to_invalidate.
     // clippy 0.1.52 (9a1dfd2dc5c 2021-04-30) in Rust 1.52.0-beta.7
+    #[cold]
+    #[inline(never)]
     #[allow(clippy::needless_collect)]
     pub fn invalidate_entries_if(&mut self, mut predicate: impl FnMut(&K, &V) -> bool) {
         let Self { cache, deques, .. } = self;
@@ -428,16 +437,19 @@ where
         self.build_hasher.hash_one(key)
     }
 
+    #[inline]
     fn record_hit(deques: &mut Deques<K>, entry: &mut ValueEntry<K, V>) {
         deques.move_to_back_ao(entry)
     }
 
+    #[inline]
     fn has_enough_capacity(&self, candidate_weight: u32, ws: u64) -> bool {
         self.max_capacity
             .map(|limit| ws + candidate_weight as u64 <= limit)
             .unwrap_or(true)
     }
 
+    #[inline]
     fn weights_to_evict(&self) -> u64 {
         self.max_capacity
             .map(|limit| self.entry_count.saturating_sub(limit))
@@ -567,6 +579,7 @@ where
         }
     }
 
+    #[inline]
     fn handle_update(
         &mut self,
         key: Rc<K>,
@@ -586,6 +599,14 @@ where
 
     #[inline]
     fn evict_lru_entries(&mut self) {
+        if self.weights_to_evict() > 0 {
+            self.do_evict_lru_entries();
+        }
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn do_evict_lru_entries(&mut self) {
         let weights_to_evict = self.weights_to_evict();
         let mut evicted_count = 0u64;
         let mut evicted_policy_weight = 0u64;


### PR DESCRIPTION
## Summary

- Added `#[inline]` attributes to hot-path public API functions (`get`, `insert`, `contains_key`, `invalidate`, `remove`) and private helpers (`record_hit`, `has_enough_capacity`, `weights_to_evict`, `handle_update`) to enable cross-crate inlining
- Added `#[inline]` to frequency sketch methods (`frequency`, `increment`, `index_of`, `increment_at`) for better inlining in the admission path
- Split `evict_lru_entries()` into a thin `#[inline]` early-return check and a `#[cold] #[inline(never)]` inner body to keep the fast path small
- Marked `invalidate_all()` and `invalidate_entries_if()` as `#[cold] #[inline(never)]` to keep bulk operations out of the hot instruction cache
- Bumped version to 0.1.8

## Files changed

- `src/unsync/cache.rs` — inline annotations on cache methods
- `src/common/frequency_sketch.rs` — inline annotations on sketch methods
- `Cargo.toml` — version bump to 0.1.8
- `CHANGELOG.md` — documented changes

## Test results

All tests pass with `RUSTFLAGS='--cfg trybuild' cargo test --all-features`. Clippy clean.