### PR TITLE
perf: defer eviction behind capacity check in insert()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.8] - 2026-02-28
+
+### Changed
+
+- Deferred `evict_lru_entries()` behind a fast capacity check so it only runs when the cache is actually over capacity, eliminating unnecessary work on every sub-capacity insert during warmup and normal operation.
+- Marked `evict_lru_entries()` as `#[cold] #[inline(never)]` since it now exclusively handles the rare over-capacity path.
+- Removed redundant unconditional `evict_lru_entries()` calls from `invalidate()` and `remove()`, which can never cause the cache to exceed capacity.
+
 ## [0.1.7] - 2026-02-28
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "micro-moka"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2018"
 rust-version = "1.76"
 

--- a/src/unsync/cache.rs
+++ b/src/unsync/cache.rs
@@ -258,7 +258,10 @@ where
     ///
     /// If the cache has this key present, the value is updated.
     pub fn insert(&mut self, key: K, value: V) {
-        self.evict_lru_entries();
+        let weights_to_evict = self.weights_to_evict();
+        if weights_to_evict > 0 {
+            self.evict_lru_entries(weights_to_evict);
+        }
         let policy_weight = 1;
         let key = Rc::new(key);
         let hash = self.hash(&key);
@@ -292,8 +295,6 @@ where
         Rc<K>: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        self.evict_lru_entries();
-
         if let Some(mut entry) = self.cache.remove(key) {
             self.deques.unlink_ao(&mut entry);
             self.entry_count -= 1;
@@ -309,8 +310,6 @@ where
         Rc<K>: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        self.evict_lru_entries();
-
         if let Some(mut entry) = self.cache.remove(key) {
             self.deques.unlink_ao(&mut entry);
             self.entry_count -= 1;
@@ -584,9 +583,10 @@ where
         deqs.move_to_back_ao(entry);
     }
 
-    #[inline]
-    fn evict_lru_entries(&mut self) {
-        let weights_to_evict = self.weights_to_evict();
+    #[cold]
+    #[inline(never)]
+    fn evict_lru_entries(&mut self, weights_to_evict: u64) {
+        debug_assert!(weights_to_evict > 0);
         let mut evicted_count = 0u64;
         let mut evicted_policy_weight = 0u64;
 
@@ -973,5 +973,90 @@ mod tests {
         assert!(debug_str.contains(r#"'b': "bob""#));
         assert!(debug_str.contains(r#"'c': "cindy""#));
         assert!(debug_str.ends_with('}'));
+    }
+
+    #[test]
+    fn sub_capacity_inserts_skip_eviction() {
+        let mut cache = Cache::new(10);
+        for i in 0u32..5 {
+            cache.insert(i, i * 10);
+        }
+        assert_eq!(cache.entry_count(), 5);
+        for i in 0u32..5 {
+            assert_eq!(cache.get(&i), Some(&(i * 10)));
+        }
+    }
+
+    #[test]
+    fn eviction_triggers_when_over_capacity() {
+        let mut cache = Cache::new(3);
+        cache.enable_frequency_sketch_for_testing();
+
+        cache.insert(1, "a");
+        cache.insert(2, "b");
+        cache.insert(3, "c");
+        assert_eq!(cache.entry_count(), 3);
+
+        // Boost frequencies of existing entries so new ones get rejected,
+        // proving eviction logic still runs.
+        for _ in 0..5 {
+            cache.get(&1);
+            cache.get(&2);
+            cache.get(&3);
+        }
+
+        cache.insert(4, "d");
+        // Cache should still be at capacity (3). The new entry was either
+        // admitted (evicting one) or rejected, but count never exceeds max.
+        assert!(cache.entry_count() <= 3);
+    }
+
+    #[test]
+    fn warmup_to_full_transition() {
+        let mut cache = Cache::new(4);
+        cache.enable_frequency_sketch_for_testing();
+
+        // Warmup phase: sub-capacity
+        cache.insert(1, "a");
+        cache.insert(2, "b");
+        assert_eq!(cache.entry_count(), 2);
+        assert_eq!(cache.weights_to_evict(), 0);
+
+        // Fill to capacity
+        cache.insert(3, "c");
+        cache.insert(4, "d");
+        assert_eq!(cache.entry_count(), 4);
+        assert_eq!(cache.weights_to_evict(), 0);
+
+        // Boost frequencies so admission works predictably
+        for _ in 0..5 {
+            cache.get(&1);
+            cache.get(&2);
+            cache.get(&3);
+            cache.get(&4);
+        }
+
+        // Over capacity: eviction must kick in
+        cache.insert(5, "e");
+        assert!(cache.entry_count() <= 4);
+    }
+
+    #[test]
+    fn invalidate_and_remove_skip_eviction_below_capacity() {
+        let mut cache = Cache::new(10);
+        cache.insert(1, "a");
+        cache.insert(2, "b");
+        cache.insert(3, "c");
+        assert_eq!(cache.entry_count(), 3);
+        assert_eq!(cache.weights_to_evict(), 0);
+
+        cache.invalidate(&1);
+        assert_eq!(cache.entry_count(), 2);
+
+        let val = cache.remove(&2);
+        assert_eq!(val, Some("b"));
+        assert_eq!(cache.entry_count(), 1);
+
+        assert_eq!(cache.get(&3), Some(&"c"));
     }
 }


### PR DESCRIPTION
## Summary

Deferred eviction behind a fast capacity check in `insert()`, eliminating unnecessary `evict_lru_entries()` overhead on sub-capacity inserts.

## Changes

- **Skip eviction when under capacity**: `insert()` now only calls `evict_lru_entries()` when the cache is actually at or over capacity, avoiding redundant work on every insert
- **Cold/non-inline eviction path**: Marked `evict_lru_entries()` as `#[cold]` `#[inline(never)]` to keep the hot insert path compact and improve instruction cache behavior
- **Pass pre-computed weights**: `evict_lru_entries()` now receives pre-computed weights as a parameter instead of recomputing them
- **Remove redundant eviction calls**: Removed unconditional `evict_lru_entries()` calls from `invalidate()` and `remove()`, which can never increase cache size

## Files changed

- `src/unsync/cache.rs` — Core optimization in insert/invalidate/remove paths
- `Cargo.toml` — Version bump to 0.1.8
- `CHANGELOG.md` — Document the optimization

## Tests

Added 4 unit tests covering:
- Sub-capacity inserts (no eviction triggered)
- Over-capacity eviction (eviction triggers correctly)
- Warmup-to-full transition behavior
- Invalidate/remove behavior (no spurious eviction)

All existing tests continue to pass.