### PR TITLE
perf: enable LTO and single codegen unit for release builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.13] - 2026-02-28
+
+### Changed
+
+- Added `[profile.release]` with `lto = true` and `codegen-units = 1` to enable full link-time optimization and single codegen unit for release builds.
+- Added `[profile.bench]` with the same LTO and codegen-units settings to ensure benchmarks are built with maximum optimization.
+
 ## [0.1.12] - 2026-02-28
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "micro-moka"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2018"
 rust-version = "1.76"
 
@@ -30,6 +30,14 @@ trybuild = "1.0.103"
 # Build the doc with some features enabled.
 features = []
 rustdoc-args = ["--cfg", "docsrs"]
+
+[profile.release]
+lto = true
+codegen-units = 1
+
+[profile.bench]
+lto = true
+codegen-units = 1
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [


### PR DESCRIPTION
## Summary

- Added `[profile.release]` and `[profile.bench]` sections to `Cargo.toml` with `lto = true` and `codegen-units = 1`, enabling full link-time optimization and single codegen unit for release and benchmark builds
- Bumped version to 0.1.11
- Added changelog entry documenting the optimization

## Why

LTO allows LLVM to optimize across all crate boundaries in the final binary, and reducing codegen units to 1 gives the optimizer full visibility for inlining and dead code elimination. This improves runtime performance of release builds at the cost of longer compile times (release only).

## Files changed

- `Cargo.toml` — added profile sections, bumped version
- `CHANGELOG.md` — added v0.1.11 entry