### PR TITLE
Move admission check before slab allocation to avoid wasted work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.17] - 2026-03-01
+
+### Changed
+
+- Moved W-TinyLFU admission check before slab allocation and hash table insertion so that rejected candidates return immediately with zero wasted work, eliminating a slab allocation, hash table insert, hash table remove, and slab deallocation per rejection.
+
 ## [0.1.16] - 2026-03-01
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "micro-moka"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2018"
 rust-version = "1.76"
 

--- a/src/unsync/cache.rs
+++ b/src/unsync/cache.rs
@@ -312,6 +312,23 @@ where
             return;
         }
 
+        if !self.has_enough_capacity(1, self.entry_count) {
+            if self.max_capacity == Some(0) {
+                return;
+            }
+
+            let candidate_freq = self.frequency_sketch.frequency(hash);
+
+            match self.admit(candidate_freq) {
+                AdmissionResult::Admitted { victim_index } => {
+                    self.remove_by_index(victim_index);
+                }
+                AdmissionResult::Rejected => {
+                    return;
+                }
+            }
+        }
+
         let slab_entry = SlabEntry {
             key,
             value,
@@ -325,7 +342,12 @@ where
         self.table
             .insert_unique(hash, idx, |&existing_idx| slab.get(existing_idx).hash);
 
-        self.handle_insert(idx, hash);
+        self.deque.push_back(&mut self.slab, idx);
+        self.entry_count += 1;
+
+        if self.should_enable_frequency_sketch() {
+            self.enable_frequency_sketch();
+        }
     }
 
     /// Discards any cached value for the key.
@@ -523,46 +545,6 @@ where
         let skt_capacity = common::sketch_capacity(cache_capacity);
         self.frequency_sketch.ensure_capacity(skt_capacity);
         self.frequency_sketch_enabled = true;
-    }
-
-    #[inline]
-    fn handle_insert(&mut self, idx: u32, hash: u64) {
-        let has_free_space = self.has_enough_capacity(1, self.entry_count);
-
-        if has_free_space {
-            self.deque.push_back(&mut self.slab, idx);
-            self.entry_count += 1;
-
-            if self.should_enable_frequency_sketch() {
-                self.enable_frequency_sketch();
-            }
-            return;
-        }
-
-        if let Some(max) = self.max_capacity {
-            if max == 0 {
-                self.remove_by_index(idx);
-                return;
-            }
-        }
-
-        let candidate_freq = self.frequency_sketch.frequency(hash);
-
-        match self.admit(candidate_freq) {
-            AdmissionResult::Admitted { victim_index } => {
-                self.remove_by_index(victim_index);
-
-                self.deque.push_back(&mut self.slab, idx);
-                self.entry_count += 1;
-
-                if self.should_enable_frequency_sketch() {
-                    self.enable_frequency_sketch();
-                }
-            }
-            AdmissionResult::Rejected => {
-                self.remove_by_index(idx);
-            }
-        }
     }
 
     #[inline]
@@ -1098,5 +1080,38 @@ mod tests {
         assert!(cache_ref.contains_key(&"b"));
         assert!(cache_ref.contains_key(&"c"));
         assert!(!cache_ref.contains_key(&"d"));
+    }
+
+    #[test]
+    fn rejected_candidate_never_visible() {
+        let mut cache = Cache::new(3);
+        cache.enable_frequency_sketch_for_testing();
+
+        cache.insert("a", "alice");
+        cache.insert("b", "bob");
+        cache.insert("c", "cindy");
+
+        for _ in 0..10 {
+            cache.get(&"a");
+            cache.get(&"b");
+            cache.get(&"c");
+        }
+
+        // "d" has never been accessed so its frequency is 0.
+        // It should be rejected without ever appearing in the cache.
+        cache.insert("d", "david");
+        assert_eq!(cache.get(&"d"), None);
+        assert!(!cache.contains_key(&"d"));
+        assert_eq!(cache.entry_count(), 3);
+        assert_eq!(cache.table.len(), 3);
+    }
+
+    #[test]
+    fn zero_capacity_insert_returns_immediately() {
+        let mut cache = Cache::new(0);
+        cache.insert("a", "alice");
+        assert_eq!(cache.entry_count(), 0);
+        assert!(!cache.contains_key(&"a"));
+        assert_eq!(cache.get(&"a"), None);
     }
 }


### PR DESCRIPTION
## Summary

Moved the W-TinyLFU admission check before slab allocation and hash table insertion in `insert()`. Previously, rejected candidates would go through the full insert path (allocate slab entry, insert into hash table) only to be immediately removed and deallocated when the admission check failed.

Now, rejected candidates return immediately without:
- Allocating a slab entry
- Inserting into the hash table
- Removing from the hash table
- Deallocating the slab entry

This eliminates 4 wasted operations per rejection.

## Changes

- **`src/unsync/cache.rs`**: Removed the `handle_insert()` method entirely, inlining its logic into `insert()` in the correct order (admission check first, then allocate/insert). Added tests for rejected candidate non-visibility and zero-capacity edge case.
- **`Cargo.toml`**: Bumped version to 0.1.17.
- **`CHANGELOG.md`**: Documented the optimization.

## Test Results

All tests pass with `RUSTFLAGS='--cfg trybuild' cargo test --all-features`.