### PR TITLE
Skip frequency sketch increment on cache misses in get()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.18] - 2026-03-01
+
+### Changed
+
+- Moved frequency sketch increment in `get()` to after the hash table hit, so cache misses skip the ~40-cycle frequency counter update entirely. Added frequency sketch increment to `insert()` so that repeated insert attempts for uncached keys still build admission frequency, preserving W-TinyLFU admission quality.
+
 ## [0.1.17] - 2026-03-01
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "micro-moka"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2018"
 rust-version = "1.76"
 

--- a/src/unsync/cache.rs
+++ b/src/unsync/cache.rs
@@ -636,18 +636,18 @@ mod tests {
         assert!(cache.contains_key(&"a"));
         assert!(cache.contains_key(&"b"));
         assert_eq!(cache.get(&"b"), Some(&"bob"));
-        // counts: a -> 1, b -> 1
+        // counts: a -> 2, b -> 2
 
         cache.insert("c", "cindy");
         assert_eq!(cache.get(&"c"), Some(&"cindy"));
         assert!(cache.contains_key(&"c"));
-        // counts: a -> 1, b -> 1, c -> 1
+        // counts: a -> 2, b -> 2, c -> 2
 
         assert!(cache.contains_key(&"a"));
         assert_eq!(cache.get(&"a"), Some(&"alice"));
         assert_eq!(cache.get(&"b"), Some(&"bob"));
         assert!(cache.contains_key(&"b"));
-        // counts: a -> 2, b -> 2, c -> 1
+        // counts: a -> 3, b -> 3, c -> 2
 
         // "d" should not be admitted because its frequency is too low.
         // Each insert attempt increments d's frequency in the sketch.

--- a/src/unsync/cache.rs
+++ b/src/unsync/cache.rs
@@ -240,7 +240,6 @@ where
         Q: Hash + Eq + ?Sized,
     {
         let hash = self.hash(key);
-        self.frequency_sketch.increment(hash);
 
         let idx = match self
             .table
@@ -250,6 +249,7 @@ where
             None => return None,
         };
 
+        self.frequency_sketch.increment(hash);
         self.deque.move_to_back(&mut self.slab, idx);
         Some(&self.slab.get(idx).value)
     }
@@ -302,6 +302,7 @@ where
         }
 
         let hash = self.hash(&key);
+        self.frequency_sketch.increment(hash);
 
         if let Some(&idx) = self
             .table
@@ -649,17 +650,18 @@ mod tests {
         // counts: a -> 2, b -> 2, c -> 1
 
         // "d" should not be admitted because its frequency is too low.
-        cache.insert("d", "david"); //   count: d -> 0
-        assert_eq!(cache.get(&"d"), None); //   d -> 1
+        // Each insert attempt increments d's frequency in the sketch.
+        cache.insert("d", "david"); //   count: d -> 1 (rejected)
         assert!(!cache.contains_key(&"d"));
+        assert_eq!(cache.get(&"d"), None); // miss: no increment
 
-        cache.insert("d", "david");
+        cache.insert("d", "david"); //   count: d -> 2 (rejected)
         assert!(!cache.contains_key(&"d"));
-        assert_eq!(cache.get(&"d"), None); //   d -> 2
+        assert_eq!(cache.get(&"d"), None); // miss: no increment
 
         // "d" should be admitted and "c" should be evicted
         // because d's frequency is higher than c's.
-        cache.insert("d", "dennis");
+        cache.insert("d", "dennis"); //   count: d -> 3
         assert_eq!(cache.get(&"a"), Some(&"alice"));
         assert_eq!(cache.get(&"b"), Some(&"bob"));
         assert_eq!(cache.get(&"c"), None);


### PR DESCRIPTION
## Summary

- Moved `frequency_sketch.increment()` in `get()` to after hit confirmation so cache misses skip the ~40-cycle frequency counter update, improving miss-path performance
- Added `frequency_sketch.increment()` to `insert()` so repeated insert attempts for uncached keys still build admission frequency, preserving W-TinyLFU admission quality
- Updated `basic_single_thread` test to build frequency via insert attempts instead of get misses
- Bumped version to 0.1.18 with changelog entry

## Files changed

- `src/unsync/cache.rs` — moved increment call in get(), added increment in insert()
- `Cargo.toml` — version bump to 0.1.18
- `CHANGELOG.md` — added entry for this optimization

## Test results

All tests pass with `RUSTFLAGS='--cfg trybuild' cargo test --all-features`.