### PR TITLE
ci: pin toml_writer for MSRV compatibility

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,6 +43,17 @@ jobs:
         if: ${{ matrix.rust == 'nightly' }}
         run: cargo update -Z minimal-versions
 
+      - name: Pin transitive deps incompatible with MSRV (MSRV only)
+        if: ${{ matrix.rust == '1.76.0' }}
+        run: |
+          rustup toolchain install stable --no-self-update --profile minimal
+          cargo +stable generate-lockfile
+          cargo +stable update toml --precise 1.0.4
+          cargo +stable update toml_datetime --precise 1.0.0
+          cargo +stable update toml_parser --precise 1.0.9
+          cargo +stable update toml_writer --precise 1.0.7
+          cargo +stable update serde_spanned --precise 1.0.4
+
       - name: Show cargo tree
         run: cargo tree
 


### PR DESCRIPTION
## Problem

CI run #148 failed on the `test (1.76.0)` MSRV job with:

```
failed to parse manifest at toml_writer-1.1.0+spec-1.1.0/Cargo.toml
feature `edition2024` is required
```

Several transitive dependencies in the toml ecosystem published v1.1.0 releases on March 22 using `edition = "2024"` (requires Rust 1.85+):
- `toml_datetime` v1.1.0
- `toml_parser` v1.1.0
- `toml_writer` v1.1.0
- `serde_spanned` v1.1.0

These are pulled in via `trybuild -> toml -> toml_*`. Since micro-moka's MSRV is 1.76.0, Cargo on that toolchain cannot even parse their manifests.

## Fix

Add a CI step for the MSRV job that:
1. Installs the stable toolchain alongside 1.76.0
2. Uses `cargo +stable` to generate a lockfile (stable can resolve all crates)
3. Pins the four edition2024 crates to their latest edition2021-compatible versions

This is a standard approach for libraries that don't commit `Cargo.lock` but need MSRV CI.