### PR TITLE
Release v1.0.0: stabilize public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2026-04-07
+
+### Changed
+
+- Promoted to stable 1.0.0 release. The public API is now considered stable and will follow semantic versioning guarantees going forward.
+
 ## [0.1.22] - 2026-03-01
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "micro-moka"
-version = "0.1.22"
+version = "1.0.0"
 edition = "2018"
 rust-version = "1.76"
 


### PR DESCRIPTION
## Release v1.0.0

Promotes micro-moka to its first stable release.

### Changes

- Version bumped from 0.1.22 to 1.0.0
- CHANGELOG entry added for 1.0.0

### What this means

The public API is now considered stable and will follow semantic versioning guarantees going forward. All breaking changes since the 0.1.0 fork from mini-moka have landed, the SIEVE eviction algorithm is battle-tested, and the slab-indexed storage architecture is mature.

### Checklist

- [x] Version bumped in Cargo.toml
- [x] CHANGELOG.md entry with date
- [x] cargo publish --dry-run --locked passes
- [x] All tests pass locally
- [x] Clippy clean